### PR TITLE
fixSourceCodeCommand

### DIFF
--- a/src/Tool-MessageFlowBrowser-Calypso/ClyShowMessageFlowCommand.class.st
+++ b/src/Tool-MessageFlowBrowser-Calypso/ClyShowMessageFlowCommand.class.st
@@ -49,5 +49,5 @@ ClyShowMessageFlowCommand >> defaultMenuItemName [
 { #category : #execution }
 ClyShowMessageFlowCommand >> execute [
 
-	messages do: [:message | MessageFlowBrowser openOn: message contextUser ]
+	MessageFlowBrowser openOn: (messages collect: [:each | each contextUser])
 ]

--- a/src/Tool-MessageFlowBrowser/MessageFlowBrowser.class.st
+++ b/src/Tool-MessageFlowBrowser/MessageFlowBrowser.class.st
@@ -29,9 +29,7 @@ MessageFlowBrowser class >> elementsMenu: aBuilder [
 	(aBuilder item: #'Message Flow')
 		keyText: 'm, f';
 		action: [ 
-			selectedMethods size = 1 
-				ifTrue: [ MessageFlowBrowser openOn: selectedMethods first ]
-				ifFalse: [ MessageFlowBrowser openOn: (MessageFlowAggregationNode children: (selectedMethods collect: [:each | each asMessageFlowNode ]) name: 'Message Flows') ]].
+			MessageFlowBrowser openOn: (selectedMethods collect: [:each | each asMessageFlowNode ]) ].
 	aBuilder withSeparatorAfter 	
 ]
 
@@ -76,5 +74,5 @@ MessageFlowBrowser class >> openOn: aSymbolOrMethod [
 			 smalltalkClass: [:each | each displaysMethod ifTrue: [ each method methodClass ] ifFalse: [ nil ]];
  			 display: [:each | each sourceCode ]].	
 		
-	^browser openOn: (Array with: aSymbolOrMethod asMessageFlowNode)
+	^browser openOn: (aSymbolOrMethod collect: [ :each | each asMessageFlowNode])
 ]

--- a/src/Tool-MessageFlowBrowser/Object.extension.st
+++ b/src/Tool-MessageFlowBrowser/Object.extension.st
@@ -9,5 +9,5 @@ Object >> asMessageFlowNode [
 { #category : #'*Tool-MessageFlowBrowser' }
 Object >> messageFlow [
 
-	^MessageFlowBrowser openOn: self asMessageFlowNode 
+	^MessageFlowBrowser openOn: {self asMessageFlowNode }
 ]

--- a/src/Tool-MessageFlowBrowser/RBMessageNode.extension.st
+++ b/src/Tool-MessageFlowBrowser/RBMessageNode.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #RBMessageNode }
+
+{ #category : #'*Tool-MessageFlowBrowser' }
+RBMessageNode >> asMessageFlowNode [
+	^self methodNode method asMessageFlowNode
+	
+
+]

--- a/src/Tool-MessageFlowBrowser/RBMessageNode.extension.st
+++ b/src/Tool-MessageFlowBrowser/RBMessageNode.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #RBMessageNode }
 
 { #category : #'*Tool-MessageFlowBrowser' }
 RBMessageNode >> asMessageFlowNode [
-	^self methodNode method asMessageFlowNode
+	^self selector asMessageFlowNode
 	
 
 ]

--- a/src/Tool-MessageFlowBrowser/RBMethodNode.extension.st
+++ b/src/Tool-MessageFlowBrowser/RBMethodNode.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #RBMethodNode }
+
+{ #category : #'*Tool-MessageFlowBrowser' }
+RBMethodNode >> asMessageFlowNode [ 
+	^self method asMessageFlowNode 
+]


### PR DESCRIPTION
1) Flow from source code command is fixed
- it was always shown RBMessageNode items but should  it open it on selected selector or method depending on cursor position.
2) Allow open message flow on multiple items: #openOn: accepts array of objects. It improves message flow from multiple method selection.